### PR TITLE
Idle time

### DIFF
--- a/factgenie/campaigns.py
+++ b/factgenie/campaigns.py
@@ -8,7 +8,6 @@ import ast
 import coloredlogs
 
 from datetime import datetime
-from apscheduler.schedulers.background import BackgroundScheduler
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -77,8 +76,10 @@ class Campaign:
         db.to_csv(self.db_path, index=False)
 
     def load_db(self):
+        dtype_dict = {"annotator_id": str, "start": float, "end": float}
+
         with open(self.db_path) as f:
-            self.db = pd.read_csv(f)
+            self.db = pd.read_csv(f, dtype=dtype_dict)
 
     def update_metadata(self):
         with open(self.metadata_path, "w") as f:
@@ -95,7 +96,7 @@ class Campaign:
 
         self.db["status"] = ExampleStatus.FREE
         self.db["annotator_id"] = ""
-        self.db["start"] = ""
+        self.db["start"] = None
         self.update_db(self.db)
 
         self.metadata["status"] = CampaignStatus.IDLE
@@ -108,7 +109,7 @@ class Campaign:
         # Update the DataFrame using .loc
         self.db.loc[mask, "status"] = ExampleStatus.FREE
         self.db.loc[mask, "annotator_id"] = ""
-        self.db.loc[mask, "start"] = ""
+        self.db.loc[mask, "start"] = None
 
         self.update_db(self.db)
 
@@ -125,23 +126,22 @@ class ExternalCampaign(Campaign):
 
 
 class HumanCampaign(Campaign):
-    def __init__(self, campaign_id):
+    def __init__(self, campaign_id, scheduler):
         super().__init__(campaign_id)
 
-        self.scheduler = BackgroundScheduler()
-        self.scheduler.add_job(self.check_idle_time, "interval", minutes=1)
-        self.scheduler.start()
-
-    def __del__(self):
-        self.scheduler.shutdown()
+        scheduler.add_job(
+            self.check_idle_time, "interval", minutes=1, id=f"idle_time_{self.campaign_id}", replace_existing=True
+        )
 
     def check_idle_time(self):
         current_time = datetime.now()
         for _, example in self.db.iterrows():
             if (
                 example.status == ExampleStatus.ASSIGNED
-                and (current_time - example.start_time).total_seconds() > self.metadata.idle_time * 60
+                and (current_time - datetime.fromtimestamp(example.start)).total_seconds()
+                > self.metadata["config"]["idle_time"] * 60
             ):
+                logger.info(f"Freeing example {example.example_idx} for {self.campaign_id} due to idle time")
                 self.clear_single_output(example.example_idx)
 
     def get_examples_for_batch(self, batch_idx):

--- a/factgenie/cli.py
+++ b/factgenie/cli.py
@@ -68,6 +68,7 @@ def create_app(**kwargs):
     import coloredlogs
     import os
     from factgenie.main import app
+    from apscheduler.schedulers.background import BackgroundScheduler
 
     logger = logging.getLogger(__name__)
 
@@ -111,6 +112,13 @@ def create_app(**kwargs):
     assert not check_login(app, "dummy_non_user_name", "dummy_bad_password"), "Login should fail for dummy user"
 
     app.db["datasets_obj"] = utils.instantiate_datasets()
+    app.db["scheduler"] = BackgroundScheduler()
+
+    logging.getLogger("apscheduler.scheduler").setLevel(logging.WARNING)
+    logging.getLogger("apscheduler.executors.default").setLevel(logging.WARNING)
+    app.db["scheduler"].start()
+
+    utils.generate_campaign_index(app)
 
     if config["debug"] is False:
         logging.getLogger("werkzeug").disabled = True

--- a/factgenie/loaders/dataset.py
+++ b/factgenie/loaders/dataset.py
@@ -183,7 +183,6 @@ class Dataset(ABC):
                     except Exception as e:
                         logger.error(f"Error parsing output file {out} at line {line_num + 1}:\n\t{e}")
                         raise e
-                logger.info(f"Loaded output file: {out}")
 
         return outputs
 

--- a/factgenie/main.py
+++ b/factgenie/main.py
@@ -873,6 +873,13 @@ def submit_annotations():
         db = campaign.db
         batch_idx = annotation_set[0]["batch_idx"]
 
+        # if the batch is not assigned to this annotator, return an error
+        if db.loc[db["batch_idx"] == batch_idx, "annotator_id"].iloc[0] != annotator_id:
+            logger.info(
+                f"Annotations rejected: batch {batch_idx} in {campaign_id} not assigned to annotator {annotator_id}"
+            )
+            return utils.error(f"Batch not assigned to annotator {annotator_id}")
+
         with open(os.path.join(save_dir, f"{batch_idx}-{annotator_id}-{now}.jsonl"), "w") as f:
             for row in annotation_set:
                 f.write(json.dumps(row) + "\n")
@@ -883,7 +890,7 @@ def submit_annotations():
         campaign.update_db(db)
         logger.info(f"Annotations for {campaign_id} (batch {batch_idx}) saved")
 
-    return jsonify({"status": "success"})
+    return utils.success()
 
 
 @app.route("/set_dataset_enabled", methods=["POST"])

--- a/factgenie/static/js/factgenie.js
+++ b/factgenie/static/js/factgenie.js
@@ -191,9 +191,19 @@ function submitAnnotations(campaign_id) {
             annotation_set: annotation_set
         }
         ),
-        success: function (data) {
+        success: function (response) {
+            console.log(response);
             window.onbeforeunload = null;
-            $("#overlay-end").show();
+
+            if (response.success !== true) {
+                $("#overlay-fail").show();
+            } else {
+                $("#overlay-end").show();
+            }
+        },
+        error: function (response) {
+            console.log(response);
+            $("#overlay-fail").show();
         }
     });
 }

--- a/factgenie/templates/campaigns/annotate_body.html
+++ b/factgenie/templates/campaigns/annotate_body.html
@@ -3,6 +3,7 @@
     <div class="container navbar-left">
       <a class="navbar-brand" href="#">
       </a>
+
       <div class="navblock" id="actions-area">
         <ul class="pagination" id="nav-example-cnt">
         </ul>
@@ -105,6 +106,24 @@
       <h1>Thank you!</h1>
 
       {{ final_message | safe }}
+    </div>
+  </div>
+
+  <div id="overlay-fail" class="overlay" style="display: none">
+    <div id="overlay-fail-content" class="overlay-content blue-link">
+      <h1>Error</h1>
+
+      <p>Sorry, your annotations could not be saved.</p>
+
+      <p>Possible reasons:
+      <ul>
+        <li>Your session has expired.</li>
+        <li>There was a problem on the server side.</li>
+      </ul>
+      </p>
+      <p>
+        For more information, please contact the administrators of this project.
+      </p>
     </div>
   </div>
 

--- a/factgenie/templates/crowdsourcing_detail.html
+++ b/factgenie/templates/crowdsourcing_detail.html
@@ -42,9 +42,13 @@
           <dt class="col-sm-3"> Status </dt>
           <dd class="col-sm-9" id="metadata-example-cnt-{{ campaign_id }}">
             <div id="metadata-example-cnt-{{ campaign_id }}">
-              {{ stats.finished }} <i class="fa fa-check"></i>
-              {{ stats.assigned }} <i class="fa fa-edit"></i>
-              {{ stats.free }} <i class="fa fa-clock-o"></i></div>
+              <span id="statusBtn{{ rowId }}" class="badge bg-finished"><i class="fa fa-check"></i> {{ stats.finished
+                }}</span>
+              <span id="statusBtn{{ rowId }}" class="badge bg-assigned"><i class="fa fa-edit"></i> {{ stats.assigned
+                }}</span>
+              <span id="statusBtn{{ rowId }}" class="badge bg-free"><i class="fa fa-clock-o"></i> {{ stats.free
+                }}</span>
+            </div>
           </dd>
         </dl>
         <div>
@@ -83,7 +87,7 @@
         <hr>
       </div>
 
-      <div id="campaign-status">
+      <div id="campaign-status" class="mb-5">
         <h4>Batches</h4>
         <table data-toggle="table" data-pagination="true" data-page-size="100" data-pagination-parts="['pageList']"
           data-detail-view-icon="true" data-search-align="left" data-detail-view="true"

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ install_requires = [
     "datasets>=2.9.0",
     "Flask-SSE>=1.0.0",
     "Flask>=2.2.2",
+    "flask_apscheduler==1.12.4",
     "json2table>=1.1.5",
     "lxml>=5.3.0",
     "Markdown>=3.7.0",

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ install_requires = [
     "datasets>=2.9.0",
     "Flask-SSE>=1.0.0",
     "Flask>=2.2.2",
-    "flask_apscheduler==1.12.4",
+    "flask_apscheduler>=1.12.4",
     "json2table>=1.1.5",
     "lxml>=5.3.0",
     "Markdown>=3.7.0",


### PR DESCRIPTION
We now use a background scheduler for automatically checking which assigned batches are over `idle_time`. 

The job runs every minute. It sets overdue examples to `free` so that they can be assigned to another annotator. 