### PR TITLE
Final message

### DIFF
--- a/factgenie/static/js/factgenie.js
+++ b/factgenie/static/js/factgenie.js
@@ -196,8 +196,10 @@ function submitAnnotations(campaign_id) {
             window.onbeforeunload = null;
 
             if (response.success !== true) {
+                $("#error-message").html(response.error);
                 $("#overlay-fail").show();
             } else {
+                $("#final-message").html(response.message);
                 $("#overlay-end").show();
             }
         },

--- a/factgenie/templates/campaigns/annotate_body.html
+++ b/factgenie/templates/campaigns/annotate_body.html
@@ -105,7 +105,8 @@
     <div id="overlay-end-content" class="overlay-content blue-link">
       <h1>Thank you!</h1>
 
-      {{ final_message | safe }}
+      <div id="final-message">
+      </div>
     </div>
   </div>
 
@@ -113,7 +114,8 @@
     <div id="overlay-fail-content" class="overlay-content blue-link">
       <h1>Error</h1>
 
-      <p>Sorry, your annotations could not be saved.</p>
+      <p>Sorry, your annotations could not be saved. Error: <span id="error-message" class="font-monospace"></span>.
+      </p>
 
       <p>Possible reasons:
       <ul>

--- a/factgenie/utils.py
+++ b/factgenie/utils.py
@@ -92,8 +92,8 @@ def format_sse(data: str, event=None) -> str:
     return msg
 
 
-def success():
-    resp = jsonify(success=True)
+def success(message=None):
+    resp = jsonify(success=True, message=message)
     return resp
 
 
@@ -500,6 +500,7 @@ def load_resources_config():
 def load_dataset_config():
     if not DATASET_CONFIG_PATH.exists():
         with open(DATASET_CONFIG_PATH, "w") as f:
+            logger.info("Creating an empty dataset config file")
             f.write("---\n")
 
     with open(DATASET_CONFIG_PATH) as f:
@@ -1136,7 +1137,6 @@ def create_crowdsourcing_page(campaign_id, config):
             parts.append(f.read())
 
     instructions_html = markdown.markdown(config["annotator_instructions"])
-    final_message_html = markdown.markdown(config["final_message"])
     has_display_overlay = config.get("has_display_overlay", True)
 
     # format only the body, keeping the unfilled templates in header and footer
@@ -1144,7 +1144,6 @@ def create_crowdsourcing_page(campaign_id, config):
 
     rendered_content = template.render(
         instructions=instructions_html,
-        final_message=final_message_html,
         annotation_span_categories=config.get("annotation_span_categories", []),
         has_display_overlay='style="display: none"' if not has_display_overlay else "",
         flags=generate_checkboxes(config.get("flags", [])),


### PR DESCRIPTION
Final message is now sent from the server side after the annotations are submitted. This prevents the annotators to find the task completion code in the page source code.

We also now display an additional text box for the preview mode, allowing to go back to the campaign list.

![screen-2024-10-15-11-09-22](https://github.com/user-attachments/assets/9bd71212-6cba-4bd7-af01-f554a1abb994)


The annotators are notified if their batch has been freed and their annotations are rejected (as the batch may be taken by another annotator):
![screen-2024-10-15-11-09-19](https://github.com/user-attachments/assets/63bdf158-5c22-4307-b335-500ead9160b9)
