### PR TITLE
Example-level fields

### DIFF
--- a/factgenie/templates/campaigns/annotate_body.html
+++ b/factgenie/templates/campaigns/annotate_body.html
@@ -78,6 +78,8 @@
               {{ flags | safe }}
 
               {{ options | safe }}
+
+              {{ text_fields | safe }}
               <div class="d-flex align-items-center justify-content-center" id="submit-annotation-box">
                 <div class="btn-group" role="group">
                   <button type="button" class="btn btn-sm btn-success" onclick="markAnnotationAsComplete();">✅ Mark

--- a/factgenie/templates/crowdsourcing_new.html
+++ b/factgenie/templates/crowdsourcing_new.html
@@ -171,7 +171,7 @@
                   <h2 class="accordion-header" id="headingAdvanced">
                     <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
                       data-bs-target="#collapseAdvanced" aria-expanded="false" aria-controls="collapseAdvanced">
-                      Advanced
+                      Example-level inputs
                     </button>
                   </h2>
                   <div id="collapseAdvanced" class="accordion-collapse collapse" aria-labelledby="headingAdvanced"
@@ -191,7 +191,7 @@
                           <button type="button" class="btn btn-outline-secondary btn-sm" onclick="addFlag();">+</button>
                         </div>
                       </div>
-                      <div class="row mb-1 align-items-center">
+                      <div class="row mb-3 align-items-center">
                         <div class="col-auto">
                           <i class="fa fa-list-ul"></i>
                           <span style="margin-left: 5px; margin-right: 10px;">List of options</span>
@@ -205,6 +205,23 @@
                           <button type="button" class="btn btn-outline-secondary btn-sm"
                             onclick="addOption();">+</button>
                         </div>
+                        <!-- text fields -->
+                        <div class="row mt-3 mb-1 align-items-center">
+                          <div class="col-auto">
+                            <i class="fa fa-file-text-o"></i>
+                            <span style="margin-left: 5px; margin-right: 10px;">Text fields</span>
+                            <div class="mb-2">
+                              <small class="form-text text-muted">Text fields that the annotators can fill for each
+                                example.</small>
+                            </div>
+                          </div>
+                          <div id="textFields"></div>
+                          <div class="col-auto mt-1">
+                            <button type="button" class="btn btn-outline-secondary btn-sm"
+                              onclick="addTextField();">+</button>
+                          </div>
+                        </div>
+
                       </div>
                     </div>
                   </div>

--- a/factgenie/utils.py
+++ b/factgenie/utils.py
@@ -1057,6 +1057,7 @@ def parse_crowdsourcing_config(config):
         "annotation_span_categories": config.get("annotationSpanCategories"),
         "flags": config.get("flags"),
         "options": config.get("options"),
+        "textFields": config.get("textFields"),
     }
 
     return config
@@ -1124,6 +1125,22 @@ def generate_options(options):
     return options_segment
 
 
+def generate_text_fields(text_fields):
+    if not text_fields:
+        return ""
+
+    text_fields_segment = "<div class='mt-2 mb-3'>"
+    for i, text_field in enumerate(text_fields):
+        text_fields_segment += f"""
+            <div class="form-group crowdsourcing-text mb-4">
+                <label for="textbox-{i}"><b>{text_field}</b></label>
+                <input type="text" class="form-control textbox-crowdsourcing" id="textbox-crowdsourcing-{i}">
+            </div>
+        """
+    text_fields_segment += "</div>"
+    return text_fields_segment
+
+
 def create_crowdsourcing_page(campaign_id, config):
     html_path = os.path.join(TEMPLATES_DIR, "campaigns", campaign_id, "annotate.html")
 
@@ -1148,6 +1165,7 @@ def create_crowdsourcing_page(campaign_id, config):
         has_display_overlay='style="display: none"' if not has_display_overlay else "",
         flags=generate_checkboxes(config.get("flags", [])),
         options=generate_options(config.get("options", [])),
+        text_fields=generate_text_fields(config.get("textFields", [])),
     )
 
     # concatenate with header and footer

--- a/factgenie/utils.py
+++ b/factgenie/utils.py
@@ -356,12 +356,12 @@ def select_batch_idx(db, seed):
         raise ValueError("No examples available")
 
     # if no free examples but still assigned examples, take the oldest assigned example
-    if len(free_examples) == 0 and len(assigned_examples) > 0:
-        free_examples = assigned_examples
-        free_examples = free_examples.sort_values(by=["start"])
-        free_examples = free_examples.head(1)
+    # if len(free_examples) == 0 and len(assigned_examples) > 0:
+    #     free_examples = assigned_examples
+    #     free_examples = free_examples.sort_values(by=["start"])
+    #     free_examples = free_examples.head(1)
 
-        logger.info(f"Annotating extra example {free_examples.index[0]}")
+    #     logger.info(f"Annotating extra example {free_examples.index[0]}")
 
     example = free_examples.sample(random_state=seed)
     batch_idx = int(example.batch_idx.values[0])
@@ -1091,7 +1091,7 @@ def generate_options(options):
         if option["type"] == "select":
             options_segment += f"""
                 <div class="form-group crowdsourcing-option option-select mb-4">
-                    <div><label for="select-{i}">{option["label"]}</label></div>
+                    <div><label for="select-{i}"><b>{option["label"]}</b></label></div>
                     <select class="form-select select-crowdsourcing mb-1" id="select-crowdsourcing-{i}">
             """
             for j, value in enumerate(option["values"]):

--- a/factgenie/utils.py
+++ b/factgenie/utils.py
@@ -1105,7 +1105,7 @@ def generate_options(options):
             # option["values"] are textual values to be displayed below the slider
             options_segment += f"""
                 <div class="form-group crowdsourcing-option option-slider mb-4">
-                    <div><label for="slider-{i}">{option["label"]}</label></div>
+                    <div><label for="slider-{i}"><b>{option["label"]}</b></label></div>
                     <div class="slider-container">
                     <input type="range" class="form-range slider-crowdsourcing" id="slider-crowdsourcing-{i}" min="0" max="{len(option["values"])-1}" list="slider-crowdsourcing-{i}-values">
                     </div>


### PR DESCRIPTION
Human campaigns can now ask for short text inputs for each example. Resolves #102.
![screen-2024-10-15-12-53-28](https://github.com/user-attachments/assets/c1067de7-d294-4a35-8c96-e38ad0b589ed)


The example-level fields (flags, options, text inputs) are now displayed in the browse interface. Resolves #87.
![screen-2024-10-15-12-54-09](https://github.com/user-attachments/assets/13c34e08-b2f4-4c9b-b8f2-fcf35c126bb5)
