### PR TITLE
Fix annotation interface

### DIFF
--- a/factgenie/static/css/custom.css
+++ b/factgenie/static/css/custom.css
@@ -900,7 +900,6 @@ a:hover {
 }
 
 .slider-crowdsourcing {
-    position: absolute;
     width: 100%;
 }
 

--- a/factgenie/static/js/factgenie.js
+++ b/factgenie/static/js/factgenie.js
@@ -21,7 +21,14 @@ if (mode == "annotate") {
 if (mode == "annotate" || mode == "browse") {
     // the draggable divider between the main area and the right panel
     var splitInstance = Split(['#centerpanel', '#rightpanel'], {
-        sizes: sizes, gutterSize: 1
+        sizes: sizes, gutterSize: 1,
+        onDrag: function () {
+            // trigger a resize update on slider inputs when the handle is dragged
+            // not a perfect solution, but it works
+            $('.slider-crowdsourcing').each(function () {
+                $(this).css('width', "80%");
+            });
+        }
     });
 }
 
@@ -261,8 +268,6 @@ function saveCurrentAnnotations(example_idx) {
     annotation_set[example_idx]["flags"] = collectFlags();
     annotation_set[example_idx]["options"] = collectOptions();
     annotation_set[example_idx]["textFields"] = collectTextFields();
-
-    console.log(annotation_set[example_idx]);
 }
 
 function clearExampleLevelFields() {

--- a/factgenie/static/js/manage.js
+++ b/factgenie/static/js/manage.js
@@ -294,7 +294,6 @@ $(document).ready(function () {
     });
 
 
-    // $("#page-input").val(example_idx);
     enableTooltips();
 });
 

--- a/factgenie/templates/crowdsourcing_new.html
+++ b/factgenie/templates/crowdsourcing_new.html
@@ -197,7 +197,7 @@
                           <span style="margin-left: 5px; margin-right: 10px;">List of options</span>
                           <div class="mb-2">
                             <small class="form-text text-muted">Options that the annotators can choose from for each
-                              example.</small>
+                              example. <b>Note that sliders are currently not working in the Safari browser.</b></small>
                           </div>
                         </div>
                         <div id="options"></div>

--- a/factgenie/utils.py
+++ b/factgenie/utils.py
@@ -1068,14 +1068,14 @@ def parse_crowdsourcing_config(config):
     return config
 
 
-def generate_checkboxes(flags):
+def generate_flags(flags):
     if not flags:
         return ""
 
     flags_segment = "<div class='mb-4'><p><b>Please check if you agree with any of the following statements:</b></p>"
     for i, flag in enumerate(flags):
         flags_segment += f"""
-            <div class="form-check flag-checkbox">
+            <div class="form-check crowdsourcing-flag">
                 <input class="form-check-input" type="checkbox" value="{i}" id="checkbox-{i}">
                 <label class="form-check-label" for="checkbox-{i}">
                     {flag}
@@ -1168,7 +1168,7 @@ def create_crowdsourcing_page(campaign_id, config):
         instructions=instructions_html,
         annotation_span_categories=config.get("annotation_span_categories", []),
         has_display_overlay='style="display: none"' if not has_display_overlay else "",
-        flags=generate_checkboxes(config.get("flags", [])),
+        flags=generate_flags(config.get("flags", [])),
         options=generate_options(config.get("options", [])),
         text_fields=generate_text_fields(config.get("text_fields", [])),
     )


### PR DESCRIPTION
Fix issues with the annotation interface UI.

We now correctly save the values of example-level inputs when switching between annotated examples.

The slider width now gets updated when the page layout is changed.

Resolves #128