### PR TITLE
fix factgenie launch; add ollama service to docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ RUN cp /usr/src/factgenie/factgenie/config/config_TEMPLATE.yml /usr/src/factgeni
 RUN pip install -e .[deploy]
 
 EXPOSE 80
-ENTRYPOINT ["gunicorn", "--env", "SCRIPT_NAME=", "-b", ":80", "-w", "1", "--threads", "8", "factgenie.cli:create_app()"]
+ENTRYPOINT ["gunicorn", "--env", "SCRIPT_NAME=", "-b", ":80", "-w", "1", "--threads", "8", "factgenie.bin.run:create_app()"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,7 @@
+# YOU NEED run once `curl http://localhost:11434/api/pull -d '{"name": "llama3.1:8b"}'`
+# after running `docker-compose up -d` from the repo root directory
+# in order to download the llama3.1:8b model which is the default model 
+# we use in the example configurations for factgenie
 services:
   factgenie:
     container_name: factgenie
@@ -5,4 +9,21 @@ services:
     restart: on-failure
     ports:
       - 8890:80
-    build: ./factgenie
+    build: ./
+  
+  # Factgenie connects to LLM inference servers either OpenAI client or Ollama
+  # Demonstrates running ollama on CPU 
+  #   For GPU run ollama without Docker
+  # or look at https://hub.docker.com/r/ollama/ollama and follow the GPU instructions
+  ollama:
+    container_name: ollama
+    image: ollama/ollama
+    restart: on-failure
+    # We need to expose the port to your machine because you need to pull models for ollama
+    # before factgenie queries the ollama server to run inference for the model.
+    # E.g. curl http://localhost:11434/api/pull -d '{"name": "llama3.1:8b"}' to download the factgenie default LLM.
+    ports:
+      - 11434:11434
+
+
+


### PR DESCRIPTION
- fix launch factgenie, which was outdated
- add ollama service with docs how to download the required model
- fix launch so it can be started without moving to the parent directory

PS: Not extensively tested because my ntb run out of space 🙃 