### PR TITLE
Support displaying overlapping annotations

### DIFF
--- a/factgenie/static/css/custom.css
+++ b/factgenie/static/css/custom.css
@@ -1012,16 +1012,6 @@ a:hover {
     filter: opacity(0.5);
 }
 
-.annotation-container {
-    position: relative;
-    display: inline-block;
-}
-
-.annotation-container div[data-bs-toggle="tooltip"] {
-    z-index: 1;
-    pointer-events: auto;
-}
-
 .out-placeholder {
     line-height: 2;
 }

--- a/factgenie/static/css/custom.css
+++ b/factgenie/static/css/custom.css
@@ -1011,3 +1011,17 @@ a:hover {
 .locked-grey h5 {
     filter: opacity(0.5);
 }
+
+.annotation-container {
+    position: relative;
+    display: inline-block;
+}
+
+.annotation-container div[data-bs-toggle="tooltip"] {
+    z-index: 1;
+    pointer-events: auto;
+}
+
+.out-placeholder {
+    line-height: 2;
+}


### PR DESCRIPTION
To support displaying external overlapping annotations in the web interface (see #159 ), we switch from highlighting to underlining.

Note that we still do not support collecting overlapping annotations from human annotators (due to technical difficulties in implementing that and potentially clumsy UX) and accordingly we also do not support collecting overlapping annotations from LLMs.