### PR TITLE
Enable displaying only model outputs with no inputs

### DIFF
--- a/factgenie/static/js/browse.js
+++ b/factgenie/static/js/browse.js
@@ -162,7 +162,18 @@ function fetchExample(dataset, split, example_idx) {
             return;
         }
         $("#dataset-spinner").hide();
-        $("#examplearea").html(data.html);
+
+        if (data.html === null) {
+            $("#centerpanel").hide();
+            // disable Split.js
+            splitInstance.setSizes([0, 100]);
+            // center the right panel
+            $("#rightpanel").css("width", "50%");
+            $("#rightpanel").css("margin", "auto");
+
+        } else {
+            $("#examplearea").html(data.html);
+        }
 
         showRawData(data);
 

--- a/factgenie/workflows.py
+++ b/factgenie/workflows.py
@@ -88,12 +88,13 @@ def get_example_data(app, dataset_id, split, example_idx, setup_id=None):
 
     try:
         html = dataset.render(example=example)
+
+        if html is not None:
+            # temporary solution for external files
+            # prefix all the "/files" calls with "app.config["host_prefix"]"
+            html = html.replace('src="/files', f'src="{app.config["host_prefix"]}/files')
     except:
         raise ValueError("Example cannot be rendered")
-
-    # temporary solution for external files
-    # prefix all the "/files" calls with "app.config["host_prefix"]"
-    html = html.replace('src="/files', f'src="{app.config["host_prefix"]}/files')
 
     if setup_id:
         generated_outputs = [


### PR DESCRIPTION
If the dataset's method `render()` returns `None`, we hide the left panel.

Resolves #162 

![screen-2024-12-02-14-17-08](https://github.com/user-attachments/assets/377fe1a7-2332-4f8f-b7ee-531fa8e9ca94)
