### PR TITLE
Add caching

### DIFF
--- a/factgenie/analysis.py
+++ b/factgenie/analysis.py
@@ -25,11 +25,11 @@ logger = logging.getLogger(__name__)
 # coloredlogs.install(level="INFO", logger=logger, fmt="%(asctime)s %(levelname)s %(message)s")
 
 
-def create_example_record(line, metadata, annotation_span_categories, annotation_records):
+def create_example_record(line, metadata, annotation_span_categories, annotation_records, jsonl_file):
     # a record is created even if there are no annotations
     j = json.loads(line)
 
-    example_record = workflows.create_annotation_example_record(j)
+    example_record = workflows.create_annotation_example_record(j, jsonl_file)
 
     for i, category in enumerate(annotation_span_categories):
         example_record["cat_" + str(i)] = 0
@@ -67,7 +67,7 @@ def load_annotations_for_campaign(campaign):
                 annotation_index += annotation_records
 
                 example_record = create_example_record(
-                    line, campaign.metadata, annotation_span_categories, annotation_records
+                    line, campaign.metadata, annotation_span_categories, annotation_records, jsonl_file
                 )
                 example_index.append(example_record)
             except Exception as e:

--- a/factgenie/app.py
+++ b/factgenie/app.py
@@ -38,6 +38,7 @@ app.db = {}
 app.db["annotation_index"] = None
 app.db["annotation_index_cache"] = {}
 app.db["output_index"] = None
+app.db["output_index_cache"] = {}
 app.db["lock"] = threading.Lock()
 app.db["running_campaigns"] = set()
 app.db["announcers"] = {}

--- a/factgenie/app.py
+++ b/factgenie/app.py
@@ -36,6 +36,7 @@ from werkzeug.middleware.proxy_fix import ProxyFix
 app = Flask("factgenie", template_folder=TEMPLATES_DIR, static_folder=STATIC_DIR)
 app.db = {}
 app.db["annotation_index"] = None
+app.db["annotation_index_cache"] = {}
 app.db["output_index"] = None
 app.db["lock"] = threading.Lock()
 app.db["running_campaigns"] = set()


### PR DESCRIPTION
Currently, the annotation and output index is completely re-generated based on the files on the filesystem at every load of the browse page. 

That keeps the indexes up to date, but it leads to significant slowdowns with a larger number of files.

Here, we implement a system of **caching annotations and model outputs**. 

👉️ We store the latest modification time of each file.
👉️ We make change to the index only for (a) files that were modified and (b) files that were deleted.

