### PR TITLE
Update annotation parsing

### DIFF
--- a/factgenie/llm_campaign.py
+++ b/factgenie/llm_campaign.py
@@ -259,6 +259,7 @@ def parse_llm_eval_config(config):
         "model": config.get("modelName"),
         "prompt_template": config.get("promptTemplate"),
         "system_msg": config.get("systemMessage"),
+        "annotation_overlap_allowed": config.get("annotationOverlapAllowed", False),
         "api_url": config.get("apiUrl"),
         "model_args": config.get("modelArguments"),
         "extra_args": config.get("extraArguments"),

--- a/factgenie/models.py
+++ b/factgenie/models.py
@@ -149,7 +149,7 @@ class LLMMetric(Model):
             start_pos = text.lower().find(annotation.text.lower(), current_pos)
 
             if start_pos == -1:
-                logger.warning(f"Cannot find {annotation=} in text {text}, skipping")
+                logger.warning(f'Cannot find {annotation=} in text "{text[current_pos:]}"')
                 continue
 
             annotation_d = annotation.model_dump()
@@ -158,7 +158,7 @@ class LLMMetric(Model):
             annotation_d["type"] = annotation.annotation_type
             del annotation_d["annotation_type"]
 
-            # logging where the annotion starts to disambiguate errors on the same string in different places
+            # Save the start position of the annotation
             annotation_d["start"] = start_pos
             annotation_list.append(annotation_d)
 

--- a/factgenie/models.py
+++ b/factgenie/models.py
@@ -129,6 +129,7 @@ class LLMMetric(Model):
         return {
             "system_msg": str,
             "start_with": str,
+            "annotation_overlap_allowed": bool,
             "api_url": str,
             "extra_args": dict,
         }
@@ -247,6 +248,7 @@ class OpenAIClientMetric(LLMMetric):
         return {
             "system_msg": str,
             "model_args": dict,
+            "annotation_overlap_allowed": bool,
             "api_url": str,  # TODO we receive it from the UI, but can be removed
             "extra_args": dict,  # TODO we receive it from the UI, but can be removed
         }

--- a/factgenie/models.py
+++ b/factgenie/models.py
@@ -156,11 +156,19 @@ class LLMMetric(Model):
             # We do not use the name "type" in JSON schema for error types because it has much broader sense in the schema (e.g. string or integer)
             annotation_d["type"] = annotation.annotation_type
             del annotation_d["annotation_type"]
+
             # logging where the annotion starts to disambiguate errors on the same string in different places
             annotation_d["start"] = start_pos
             annotation_list.append(annotation_d)
 
-            current_pos = start_pos + len(annotation.text)  # does not allow for overlapping annotations
+            overlap_allowed = self.config.get("annotation_overlap_allowed", False)
+
+            if overlap_allowed:
+                # move the current position to the start of the annotation
+                current_pos = start_pos
+            else:
+                # move the current position to the end of the annotation
+                current_pos = start_pos + len(annotation.text)
 
         return annotation_list
 

--- a/factgenie/models.py
+++ b/factgenie/models.py
@@ -135,13 +135,14 @@ class LLMMetric(Model):
 
     def parse_annotations(self, text, annotations_json):
         try:
-            annotations_obj = OutputAnnotations.parse_raw(annotations_json)
+            annotations_obj = OutputAnnotations.model_validate_json(annotations_json)
             annotations = annotations_obj.annotations
         except ValidationError as e:
             logger.error(f"LLM response in not in the expected format: {e}\n\t{annotations_json=}")
 
         annotation_list = []
         current_pos = 0
+
         for annotation in annotations:
             # find the `start` index of the error in the text
             start_pos = text.lower().find(annotation.text.lower(), current_pos)
@@ -150,7 +151,7 @@ class LLMMetric(Model):
                 logger.warning(f"Cannot find {annotation=} in text {text}, skipping")
                 continue
 
-            annotation_d = annotation.dict()
+            annotation_d = annotation.model_dump()
             # For backward compatibility let's use shorter "type"
             # We do not use the name "type" in JSON schema for error types because it has much broader sense in the schema (e.g. string or integer)
             annotation_d["type"] = annotation.annotation_type

--- a/factgenie/static/js/campaigns.js
+++ b/factgenie/static/js/campaigns.js
@@ -226,6 +226,7 @@ function gatherConfig() {
         config.modelName = $("#model-name").val();
         config.promptTemplate = $("#prompt-template").val();
         config.systemMessage = $("#system-message").val();
+        config.annotationOverlapAllowed = $("#annotationOverlapAllowed").is(":checked");
         config.apiUrl = $("#api-url").val();
         config.modelArguments = getKeysAndValues($("#model-arguments"));
         config.extraArguments = getKeysAndValues($("#extra-arguments"));
@@ -605,6 +606,7 @@ function updateLLMMetricConfig() {
         $("#model-arguments").empty();
         $("#annotation-span-categories").empty();
         $("#extra-arguments").empty();
+        $("#annotationOverlapAllowed").prop("checked", false);
         return;
     }
     const cfg = window.configs[llmConfigValue];
@@ -613,6 +615,7 @@ function updateLLMMetricConfig() {
     const model_name = cfg.model;
     const prompt_template = cfg.prompt_template;
     const system_msg = cfg.system_msg;
+    const annotation_overlap_allowed = cfg.annotation_overlap_allowed;
     const api_url = cfg.api_url;
     const model_args = cfg.model_args;
     const extra_args = cfg.extra_args;
@@ -622,6 +625,7 @@ function updateLLMMetricConfig() {
     $("#model-name").html(model_name);
     $("#prompt-template").html(prompt_template);
     $("#system-message").html(system_msg);
+    $("#annotationOverlapAllowed").prop("checked", annotation_overlap_allowed);
     $("#api-url").html(api_url);
     $("#model-arguments").empty();
     $("#extra-arguments").empty();

--- a/factgenie/templates/pages/llm_campaign_new.html
+++ b/factgenie/templates/pages/llm_campaign_new.html
@@ -227,6 +227,20 @@
                     onclick="addExtraArgument();">+</button>
                 </div>
               </div>
+
+              {% if mode == 'llm_eval' %}
+              <div class="form-group mt-4 mb-3">
+                <i class="fa fa-flag-checkered"></i>
+                <label style="margin-left: 5px; margin-right: 10px;" for="annotationOverlapAllowed">Allow overlapping annotations</label>
+                <div class="mb-2">
+                  <small class="form-text text-muted">Whether the model should be allowed to produce overlapping annotations.</small>
+                </div>
+                <div class="form-check form-switch">
+                  <input type="checkbox" class="form-check-input" id="annotationOverlapAllowed" name="annotationOverlapAllowed">
+                </div>
+              </div>
+              {% endif %}
+
             </div>
             <div style="text-align: center;">
               <button type="button" class="btn btn-outline-secondary mt-3"


### PR DESCRIPTION
This pull request:

- integrates JSON schema using Pydantic with `OllamaMetric` (requires Ollama [>0.50](https://github.com/ollama/ollama/releases/tag/v0.5.0)),
- enables decoding overlapping annotations from LLM evaluators.

I don't think it's currently necessary to include the full JSON schema in the prompt, as it looks quite messy. So I suggest we close #176 (but feel free to implement that).