### PR TITLE
Adjust selects and sliders

### DIFF
--- a/factgenie/analysis.py
+++ b/factgenie/analysis.py
@@ -184,11 +184,14 @@ def compute_extra_fields_stats(example_index):
     extra_fields_stats = {}
 
     try:
-        for field in ["flags", "options", "text_fields"]:
+        for field in ["flags", "options", "sliders", "text_fields"]:
             # each of `example_index[field]` is a list of dicts
             # each dict contains `label` and `value` keys
             # we want to count the number of occurrences of each `value` for each unique `label`
             # and then assign the dictionary with these counts to extra_fields_stats[label]
+
+            if field not in example_index.columns:
+                continue
 
             # find unique labels
             labels = set()
@@ -348,6 +351,7 @@ def compute_gamma_spans(app, selected_campaigns, campaigns):
             "annotation_overlap_allowed",
             "flags",
             "options",
+            "sliders",
             "text_fields",
             "jsonl_file",
             "annotation_text",

--- a/factgenie/config/crowdsourcing/example-tutorial.yaml
+++ b/factgenie/config/crowdsourcing/example-tutorial.yaml
@@ -47,5 +47,6 @@ flags: []
 idle_time: 60
 options: []
 service: local
+sliders: []
 sort_order: shuffle-all
 text_fields: []

--- a/factgenie/config/crowdsourcing/example.yaml
+++ b/factgenie/config/crowdsourcing/example.yaml
@@ -43,6 +43,7 @@ flags:
 - The text is severely off-topic (seems completely unrelated to the data).
 idle_time: 120
 options: []
+sliders: []
 service: prolific
 sort_order: sort-example-ids-shuffle-setups
 text_fields: []

--- a/factgenie/datasets/propaganda_techniques.py
+++ b/factgenie/datasets/propaganda_techniques.py
@@ -341,6 +341,7 @@ class PropagandaTechniques(Dataset):
                 "annotation_span_categories": PTC_span_categories,
                 "flags": [],
                 "options": [],
+                "sliders": [],
                 "text_fields": [],
             },
             "created": "2024-03-25 00:00:00",

--- a/factgenie/static/js/browse.js
+++ b/factgenie/static/js/browse.js
@@ -241,6 +241,7 @@ function getExampleLevelFields(annotations) {
     // show `outputs.flags`, `outputs.options`, and `outputs.textFields`
     var flags = annotations.flags;
     var options = annotations.options;
+    var sliders = annotations.sliders;
     var textFields = annotations.text_fields;
 
     var html = $('<div>', { class: "p-2 extra-fields" });
@@ -269,6 +270,19 @@ function getExampleLevelFields(annotations) {
             optionsDiv.append(valueDiv);
         }
         html.append(optionsDiv);
+    }
+
+    if (sliders !== undefined && sliders.length > 0) {
+        var slidersDiv = $('<div>', { class: "small" });
+
+        for (const slider of sliders) {
+            var labelDiv = $('<div>', { class: "small text-muted" }).text(`${slider.label}`);
+            var valueDiv = $('<div>', { class: "small mb-1 fw-bold" }).text(`${slider.value}`);
+
+            slidersDiv.append(labelDiv);
+            slidersDiv.append(valueDiv);
+        }
+        html.append(slidersDiv);
     }
 
     if (textFields !== undefined && textFields.length > 0) {

--- a/factgenie/static/js/campaigns.js
+++ b/factgenie/static/js/campaigns.js
@@ -220,6 +220,7 @@ function gatherConfig() {
         config.annotationSpanCategories = getAnnotationSpanCategories();
         config.flags = getKeys($("#flags"));
         config.options = getOptions();
+        config.sliders = getSliders();
         config.textFields = getKeys($("#textFields"));
     } else if (window.mode == "llm_eval" || window.mode == "llm_gen") {
         config.metricType = $("#metric-type").val();
@@ -531,6 +532,7 @@ function updateCrowdsourcingConfig() {
         $("#annotation-span-categories").empty();
         $("#flags").empty();
         $("#options").empty();
+        $("#sliders").empty();
         $("#textFields").empty();
         return;
     }
@@ -548,6 +550,7 @@ function updateCrowdsourcingConfig() {
     const annotationSpanCategories = cfg.annotation_span_categories;
     const flags = cfg.flags;
     const options = cfg.options;
+    const sliders = cfg.sliders;
     const textFields = cfg.text_fields;
 
     annotatorInstructionsMDE.value(annotatorInstructions);
@@ -578,8 +581,17 @@ function updateCrowdsourcingConfig() {
 
     if (options !== undefined) {
         options.forEach((option) => {
-            const newOption = createOptionElem(option.type, option.label, option.values.join(", "));
+            const newOption = createOptionElem(option.label, option.values.join(", "));
             $("#options").append(newOption);
+        });
+    }
+
+    $("#sliders").empty();
+
+    if (sliders !== undefined) {
+        sliders.forEach((slider) => {
+            const newSlider = createSliderElem(slider.label, slider.min, slider.max, slider.step);
+            $("#sliders").append(newSlider);
         });
     }
 

--- a/factgenie/static/js/render-sliders.js
+++ b/factgenie/static/js/render-sliders.js
@@ -1,38 +1,16 @@
 $(document).ready(function () {
-    function adjustSliders() {
-        // find all the sliders of class ".slider-crowdsourcing"
-        const sliders = $('.slider-crowdsourcing');
+    const sliders = $('.slider-crowdsourcing');
 
-        for (let i = 0; i < sliders.length; i++) {
-            const slider = sliders.eq(i);
-            // we need to find the datalist of the slider
-            // the slider has an id "slider-crowdsourcing-{i}"
-            // the datalist has an id "slider-crowdsourcing-{i}-values"
-            // we cannot use the iteration index since there may be also selectboxes
-            const sliderValues = $(`#${slider.attr('id')}-values`);
-            const sliderOptions = sliderValues.find('option');
+    sliders.each(function (index) {
+        const sliderId = $(this).attr('id');
+        const valueDisplayId = `${sliderId}-value`;
 
-            if (sliderOptions.length > 1) {
-                const firstOption = sliderOptions.first();
-                const lastOption = sliderOptions.last();
+        // Set initial value
+        $(`#${valueDisplayId}`).text($(`#${valueDisplayId}`).data('default-value'));
 
-                const firstOptionCenter = firstOption.position().left + firstOption.outerWidth() / 2;
-                const lastOptionCenter = lastOption.position().left + lastOption.outerWidth() / 2;
-
-                const sliderWidth = lastOptionCenter - firstOptionCenter;
-
-                // hardcoded padding of the outside box;
-                const leftOffset = firstOptionCenter - 22;
-
-                slider.css('width', `${sliderWidth}px`);
-                slider.css('left', `${leftOffset}px`);
-            }
-        }
-    }
-
-    // Initial adjustment
-    adjustSliders();
-
-    // Adjust on window resize
-    $(window).resize(adjustSliders);
+        // Update value on slider change
+        $(this).on('input change', function () {
+            $(`#${valueDisplayId}`).text($(this).val());
+        });
+    });
 });

--- a/factgenie/static/js/utils.js
+++ b/factgenie/static/js/utils.js
@@ -54,8 +54,14 @@ function addFlag() {
 
 function addOption() {
     const options = $("#options");
-    const newOption = createOptionElem("select", "", "");
+    const newOption = createOptionElem("", "");
     options.append(newOption);
+}
+
+function addSlider() {
+    const sliders = $("#sliders");
+    const newSlider = createSliderElem("", "", "", "");
+    sliders.append(newSlider);
 }
 
 function addTextField() {
@@ -84,20 +90,14 @@ function createFlagElem(key) {
     return newFlag;
 }
 
-function createOptionElem(type, label, values) {
+function createOptionElem(label, values) {
     // three columns: option type (selectbox, slider) text input for the label, and text input for comma-separated values
     const newOption = $(`
         <div class="row mt-1">
-        <div class="col-3">
-        <select class="form-select" name="optionType">
-            <option value="select" ${type === 'select' ? 'selected' : ''}>Select box</option>
-            <option value="slider" ${type === 'slider' ? 'selected' : ''}>Slider</option>
-        </select>
-        </div>
-        <div class="col-3">
+        <div class="col-4">
         <input type="text" class="form-control" name="optionLabel" value="${label}" placeholder="Label">
         </div>
-        <div class="col-5">
+        <div class="col-7">
         <input type="text" class="form-control" name="optionValues" value="${values}" placeholder="Comma-separated values">
         </div>
         <div class="col-1">
@@ -105,6 +105,30 @@ function createOptionElem(type, label, values) {
         </div>
         `);
     return newOption;
+}
+
+function createSliderElem(key, min, max, step) {
+    // three columns: option type (selectbox, slider) text input for the label, and text input for comma-separated values
+    const newSlider = $(`
+        <div class="row mt-1">
+        <div class="col-5">
+        <input type="text" class="form-control" name="sliderLabel" value="${key}" placeholder="Label">
+        </div>
+        <div class="col-2">
+        <input type="number" class="form-control" name="sliderMin" value="${min}" placeholder="Min">
+        </div>
+        <div class="col-2">
+        <input type="number" class="form-control" name="sliderMax" value="${max}" placeholder="Max">
+        </div>
+        <div class="col-2">
+        <input type="number" class="form-control" name="sliderStep" value="${step}" placeholder="Step">
+        </div>
+        <div class="col-1">
+        <button type="button" class="btn btn-danger" onclick="deleteRow(this);">x</button>
+        </div>
+        </div>
+    `);
+    return newSlider;
 }
 
 function createTextFieldElem(key) {
@@ -249,13 +273,27 @@ function getOptions() {
     var options = [];
 
     $("#options").children().each(function () {
-        const type = $(this).find("select[name='optionType']").val();
         const label = $(this).find("input[name='optionLabel']").val();
         const values = $(this).find("input[name='optionValues']").val().split(",").map(v => v.trim());
-        options.push({ type: type, label: label, values: values });
+        options.push({ label: label, values: values });
     });
     return options;
 }
+
+function getSliders() {
+    var sliders = [];
+
+    $("#sliders").children().each(function () {
+        const label = $(this).find("input[name='sliderLabel']").val();
+        const min = $(this).find("input[name='sliderMin']").val();
+        const max = $(this).find("input[name='sliderMax']").val();
+        const step = $(this).find("input[name='sliderStep']").val();
+
+        sliders.push({ label: label, min: min, max: max, step: step });
+    });
+    return sliders;
+}
+
 
 function mod(n, m) {
     return ((n % m) + m) % m;

--- a/factgenie/templates/crowdsourcing/annotate_body.html
+++ b/factgenie/templates/crowdsourcing/annotate_body.html
@@ -57,7 +57,8 @@
             </div>
             <div id='output-content'>
               <div>
-                <div class="mt-3 mb-4 d-flex flex-wrap gap-1 align-items-center" role="group" aria-label="Basic radio toggle button group">
+                <div class="mt-3 mb-4 d-flex flex-wrap gap-1 align-items-center" role="group"
+                  aria-label="Basic radio toggle button group">
                   {% for category in annotation_span_categories %}
                   <input type="radio" class="btn-check btn-outline-secondary btn-err-cat" name="btnradio"
                     id="btnradio{{ loop.index }}" autocomplete="off" {% if loop.first %}checked{% endif %}
@@ -90,6 +91,8 @@
               {{ flags | safe }}
 
               {{ options | safe }}
+
+              {{ sliders | safe }}
 
               {{ text_fields | safe }}
               <div class="d-flex align-items-center justify-content-center" id="submit-annotation-box">

--- a/factgenie/templates/crowdsourcing/annotate_body.html
+++ b/factgenie/templates/crowdsourcing/annotate_body.html
@@ -71,13 +71,15 @@
                   <div class="ms-auto">
                     <input type="radio" class="btn-check btn-outline-secondary btn-select" name="btnradio"
                       id="btnradioselect" autocomplete="off" data-cat-idx="-2">
-                    <label class="btn btn-err-cat-label" for="btnradioselect" style="background-color: #FFF; color: #000 !important;">
-                      <i class="fa fa-mouse-pointer" aria-hidden="true"></i> Select mode
+                    <label class="btn btn-err-cat-label" for="btnradioselect"
+                      style="background-color: #FFF; color: #000 !important;">
+                      <i class="fa fa-mouse-pointer" aria-hidden="true"></i>
                     </label>
                     <input type="radio" class="btn-check btn-outline-secondary btn-eraser" name="btnradio"
                       id="btnradioeraser" autocomplete="off" data-cat-idx="-1">
-                    <label class="btn btn-err-cat-label" for="btnradioeraser" style="background-color: #FFF; color: #000 !important;">
-                      <i class="fa fa-eraser" aria-hidden="true"></i> Erase mode
+                    <label class="btn btn-err-cat-label" for="btnradioeraser"
+                      style="background-color: #FFF; color: #000 !important;">
+                      <i class="fa fa-eraser" aria-hidden="true"></i>
                     </label>
                   </div>
                 </div>

--- a/factgenie/templates/pages/crowdsourcing_new.html
+++ b/factgenie/templates/pages/crowdsourcing_new.html
@@ -150,10 +150,12 @@
               <div class="form-group mt-4">
                 <label for="annotationOverlapAllowed">Allow overlapping annotations</label>
                 <div class="mb-2">
-                  <small class="form-text text-muted">Whether annotators can annotate the same part of the text multiple times</small>
+                  <small class="form-text text-muted">Whether annotators can annotate the same part of the text multiple
+                    times</small>
                 </div>
                 <div class="form-check form-switch">
-                  <input type="checkbox" class="form-check-input" id="annotationOverlapAllowed" name="annotationOverlapAllowed">
+                  <input type="checkbox" class="form-check-input" id="annotationOverlapAllowed"
+                    name="annotationOverlapAllowed">
                 </div>
               </div>
               <div class="form-group mt-4">
@@ -212,7 +214,7 @@
                           <span style="margin-left: 5px; margin-right: 10px;">List of options</span>
                           <div class="mb-2">
                             <small class="form-text text-muted">Options that the annotators can choose from for each
-                              example. <b>Note that sliders are currently not working in the Safari browser.</b></small>
+                              example.</small>
                           </div>
                         </div>
                         <div id="options"></div>
@@ -220,24 +222,42 @@
                           <button type="button" class="btn btn-outline-secondary btn-sm"
                             onclick="addOption();">+</button>
                         </div>
-                        <!-- text fields -->
-                        <div class="row mt-3 mb-1 align-items-center">
-                          <div class="col-auto">
-                            <i class="fa fa-file-text-o"></i>
-                            <span style="margin-left: 5px; margin-right: 10px;">Text fields</span>
-                            <div class="mb-2">
-                              <small class="form-text text-muted">Text fields that the annotators can fill for each
-                                example.</small>
-                            </div>
-                          </div>
-                          <div id="textFields"></div>
-                          <div class="col-auto mt-1">
-                            <button type="button" class="btn btn-outline-secondary btn-sm"
-                              onclick="addTextField();">+</button>
+                      </div>
+                      <!-- sliders -->
+                      <div class="row mb-3 mt-3 align-items-center">
+                        <div class="col-auto">
+                          <i class="fa fa-sliders"></i>
+                          <span style="margin-left: 5px; margin-right: 10px;">Sliders</span>
+                          <div class="mb-2">
+                            <small class="form-text text-muted">Slider with values that the annotators can select for
+                              each
+                              example.</small>
                           </div>
                         </div>
-
+                        <div id="sliders"></div>
+                        <div class="col-auto mt-1">
+                          <button type="button" class="btn btn-outline-secondary btn-sm"
+                            onclick="addSlider();">+</button>
+                        </div>
                       </div>
+
+                      <!-- text fields -->
+                      <div class="row mt-3 mb-1 align-items-center">
+                        <div class="col-auto">
+                          <i class="fa fa-file-text-o"></i>
+                          <span style="margin-left: 5px; margin-right: 10px;">Text fields</span>
+                          <div class="mb-2">
+                            <small class="form-text text-muted">Text fields that the annotators can fill for each
+                              example.</small>
+                          </div>
+                        </div>
+                        <div id="textFields"></div>
+                        <div class="col-auto mt-1">
+                          <button type="button" class="btn btn-outline-secondary btn-sm"
+                            onclick="addTextField();">+</button>
+                        </div>
+                      </div>
+
                     </div>
                   </div>
                 </div>

--- a/factgenie/workflows.py
+++ b/factgenie/workflows.py
@@ -214,6 +214,7 @@ def create_annotation_example_record(j, jsonl_file):
         "split": slugify(j["split"]),
         "flags": j.get("flags", []),
         "options": j.get("options", []),
+        "sliders": j.get("sliders", []),
         "text_fields": j.get("text_fields", []),
         "jsonl_file": jsonl_file,
     }
@@ -939,6 +940,7 @@ def save_record(mode, campaign, row, result):
         record["annotations"] = result["annotations"]
         record["flags"] = result.get("flags", [])
         record["options"] = result.get("options", [])
+        record["sliders"] = result.get("sliders", [])
         record["text_fields"] = result.get("text_fields", [])
 
     if mode == CampaignMode.LLM_EVAL:


### PR DESCRIPTION
This pull request:

**1) Replaces "option sliders" with "min-max-step sliders"**
Currently, we treated sliders the same way as select boxes: we used a list of options.

<img src="https://github.com/user-attachments/assets/96b6dd68-debe-4f80-8055-409c0642792d" width="600px">

This introduced several issues that were hard to fix:
- The slider used the `datalist` elements that did not work in Safari.
- The slider did not correctly display long ranges such as 0-100 scale.
- We could not control whether the user has already selected a value or not (see the next point).

Therefore, we decided to use a more standard way that the [range sliders should be used](https://getbootstrap.com/docs/5.2/forms/range/). Specifically, the user specifies the minimum, maximum and step, generating an integer range. The slider element then displays only the minimum, maximum, and currently selected value.

<img src="https://github.com/user-attachments/assets/12843eb7-a36f-4747-bc0e-0e75abf3a4ea" width="600px">

That means that the sliders **cannot be used anymore for a list of textual options** ❗️Instead, we recommend using a select box in these cases.

**2) Disables default values for selects and sliders.**

Having the first value as selected by default could bias the annotators towards selecting certain values. 

We now prevent this:

- For select boxes, there is the default "Select an option..." option that _needs_ to be changed before marking example as complete:

<img src="https://github.com/user-attachments/assets/4e8e6465-45cd-437b-9a32-39fb88ed0c5c" width="600px">

- For sliders, we unfortunately cannot hide the handle. We at least force the annotator to interact with the slider: we set the default "?" value that _needs_ to be changed before marking example as complete:

<img src="https://github.com/user-attachments/assets/5e3ba1b2-9c6d-4894-ae1c-987bd2739fea" width="600px">

Resolves #215.
