### PR TITLE
Consider annotator group to be the property of individual examples

### DIFF
--- a/factgenie/app.py
+++ b/factgenie/app.py
@@ -268,10 +268,9 @@ def clear_output():
     data = request.get_json()
     campaign_id = data.get("campaignId")
     idx = int(data.get("idx"))
-    annotator_group = int(data.get("annotatorGroup"))
 
     campaign = workflows.load_campaign(app, campaign_id=campaign_id)
-    campaign.clear_output(idx, annotator_group)
+    campaign.clear_output(idx)
 
     return utils.success()
 

--- a/factgenie/static/js/campaigns.js
+++ b/factgenie/static/js/campaigns.js
@@ -19,9 +19,9 @@ function clearCampaign(campaignId) {
     });
 }
 
-function clearOutput(campaignId, mode, idx, annotatorGroup) {
+function clearOutput(campaignId, mode, idx) {
     // ask for confirmation
-    if (!confirm(`Are you sure you want to free the batch id ${idx} (annotator group ${annotatorGroup})? All related outputs will be deleted.`)) {
+    if (!confirm(`Are you sure you want to free the batch id ${idx}? All related outputs will be deleted.`)) {
         return;
     }
     $.post({
@@ -31,7 +31,6 @@ function clearOutput(campaignId, mode, idx, annotatorGroup) {
             campaignId: campaignId,
             mode: mode,
             idx: idx,
-            annotatorGroup: annotatorGroup
         }),
         success: function (response) {
             console.log(response);

--- a/factgenie/templates/pages/crowdsourcing_detail.html
+++ b/factgenie/templates/pages/crowdsourcing_detail.html
@@ -97,7 +97,6 @@
           <thead>
             <tr>
               <th scope="col" data-sortable="true">Batch id</th>
-              <th scope="col" data-sortable="true">Ann. group</th>
               <th scope="col" data-sortable="true">Examples</th>
               <th scope="col" data-sortable="true">Status</th>
               <th scope="col" data-sortable="true">Annotator id</th>
@@ -112,7 +111,6 @@
             {% set rowId = (batch.batch_idx|string) %}
             <tr>
               <td>{{ batch.batch_idx }}</td>
-              <td>{{ batch.annotator_group }}</td>
               <td>{{ batch.example_cnt }}</td>
               <td><span id="statusBtn{{ rowId }}" class="badge bg-{{ batch.status }}">{{ batch.status }}</span>
               </td>
@@ -126,7 +124,7 @@
                   <i class="fa fa-eye"></i>
                 </a>
                 <a class="btn btn-sm btn-outline-secondary"
-                  onclick="clearOutput('{{ metadata.id }}', '{{ mode }}', '{{ batch.batch_idx }}', {{ batch.annotator_group }})"
+                  onclick="clearOutput('{{ metadata.id }}', '{{ mode }}', '{{ batch.batch_idx }}')"
                   data-bs-toggle="tooltip" title="Clear outputs and set free" id="clearOutput{{ rowId }}"
                   aria-controls="collapseExample" {% if batch.status=='free' %} style="display: none;" {% endif %}>
                   <i class="fa fa-recycle"></i>
@@ -141,6 +139,7 @@
                         <th>Split</th>
                         <th>Setup id</th>
                         <th>Example idx</th>
+                        <th>Ann. group</th>
                         <th>Link</th>
                       </tr>
                     </thead>
@@ -151,6 +150,7 @@
                         <td>{{ e.split }}</td>
                         <td>{{ e.setup_id }}</td>
                         <td>{{ e.example_idx }}</td>
+                        <td>{{ e.annotator_group }}</td>
                         <td><a
                             href="{{ host_prefix }}/browse?dataset={{ e.dataset }}&split={{ e.split }}&example_idx={{ e.example_idx }}&setup_id={{ e.setup_id }}"
                             class="blue-link" target="_blank">

--- a/factgenie/templates/pages/llm_campaign_detail.html
+++ b/factgenie/templates/pages/llm_campaign_detail.html
@@ -131,7 +131,7 @@
                   </td>
                   <td>
                     <a class="btn btn-sm btn-outline-secondary"
-                      onclick="clearOutput('{{ metadata.id }}', '{{ mode }}', '{{ example.example_idx }}', {{ example.annotator_group }})"
+                      onclick="clearOutput('{{ metadata.id }}', '{{ mode }}', '{{ example.example_idx }}')"
                       data-bs-toggle="tooltip" title="Clear outputs" id="clearOutput{{ rowId }}"
                       aria-controls="collapseExample" {% if example.status !='finished' %} style="display: none;" {%
                       endif %}>


### PR DESCRIPTION
Until now, it was not possible to use different annotator groups within a batch, since we identified each set of examples as an `(batch_idx, annotator_group)` pair.

However, this prevented creating heterogenous batches in which `annotator_group` would differ. These could be useful, for example, when manually inserting some repeating examples into the campaign as checks.

From now, we consider `annotator_group` separately for each example.

That also means that `batch_idx` is now a unique identifier of a set of examples assigned to an annotator. For example, if a set of 20 outputs is to be annotated by 5 annotators each, we'll have batch numbers 0-99.

We still keep the property that a batch containing the lowest available annotator group will be prefered when assigning a batch to an annotator, so that the batches with annotator_group 0, 1, etc. get annotated sequentially.

Tagging @patuchen since she might be interested in this.