### PR TITLE
Focus a campaign using an URL argument

### DIFF
--- a/factgenie/app.py
+++ b/factgenie/app.py
@@ -225,6 +225,7 @@ def browse():
     split = request.args.get("split")
     example_idx = request.args.get("example_idx")
     setup_id = request.args.get("setup_id")
+    ann_campaign = request.args.get("ann_campaign")
 
     if dataset_id and split and example_idx:
         display_example = {"dataset": dataset_id, "split": split, "example_idx": int(example_idx)}
@@ -245,6 +246,7 @@ def browse():
         "pages/browse.html",
         display_example=display_example,
         highlight_setup_id=setup_id,
+        highlight_ann_campaign=ann_campaign,
         datasets=datasets,
         host_prefix=app.config["host_prefix"],
     )

--- a/factgenie/templates/pages/browse.html
+++ b/factgenie/templates/pages/browse.html
@@ -185,6 +185,7 @@
   window.display_example = {{ display_example | tojson | safe }};
   window.datasets = {{ datasets | tojson | safe }};
   window.highlight_setup_id = "{{ highlight_setup_id }}";
+  window.highlight_ann_campaign = "{{ highlight_ann_campaign }}";
   window.mode = "browse";
 </script>
 


### PR DESCRIPTION
The `ann_campaign` argument can be now used in the permalink. If the value is a valid campaign id, it will focus annotations from a given campaign id.

Along with that, `setup_id` can still be used to highlight a specific setup.