### PR TITLE
Improved templating

### DIFF
--- a/factgenie/prompting.py
+++ b/factgenie/prompting.py
@@ -22,10 +22,10 @@ class PromptingStrategy(abc.ABC):
 
     def prompt(self, data, to_annotate: str = "{text}"):
         data = self.preprocess_data_for_prompt(data)
+        keyword_dict = { "data": data, "text": to_annotate }
 
         prompt_template = self.config["prompt_template"]
-        prompt_template = template_replace(prompt_template, "data", data)
-        prompt_template = prompt_template.replace("{text}", to_annotate)
+        prompt_template = template_replace(prompt_template, keyword_dict)
 
         return prompt_template
 

--- a/factgenie/prompting.py
+++ b/factgenie/prompting.py
@@ -9,6 +9,7 @@ import json
 from pydantic import ValidationError
 from factgenie.annotations import AnnotationModelFactory
 from factgenie.api import ModelAPI
+from factgenie.text_processing import template_replace
 
 logger = logging.getLogger("factgenie")
 
@@ -19,20 +20,16 @@ class PromptingStrategy(abc.ABC):
         self.extra_args = config.get("extra_args", {})
         self.prompt_strat_kwargs = {}
 
-    def prompt(self, data, to_annotate: str = "{text}"):
-        prompt_template = self.config["prompt_template"]
+    def prompt(self, data, to_annotate: str = "{text}", template_override=None):
+        if template_override is not None:
+            prompt_template = template_override
+        else:
+            prompt_template = self.config["prompt_template"]
+
         data = self.preprocess_data_for_prompt(data)
 
-        # Replace the placeholders (e.g., {text}) in the prompt template with the actual values
-        if type(data) == dict:
-            for key in data.keys():
-                prompt_template = prompt_template.replace(f"{{data[{key}]}}", str(data[key]))
-
-        matches = re.findall(r"{data\[[^\[\]]*\]}", prompt_template)
-        if len(matches) > 0:
-            logger.warning(f"Unreplaced data keys in the template: {', '.join(matches)}")
-
-        prompt_template = prompt_template.replace("{data}", str(data)).replace("{text}", to_annotate)
+        prompt_template = template_replace(prompt_template, "data", data)
+        prompt_template = prompt_template.replace("{text}", to_annotate)
 
         return prompt_template
 
@@ -378,94 +375,6 @@ class RawOutputStrategy(AnnotationsStrategy):
                 ret["thinking_trace"] = extracted["thinking_trace"]
 
             return ret
-        except Exception as e:
-            traceback.print_exc()
-            logger.error(e)
-            raise e
-
- class MultiStepPrompting(RawOutputStrategy):
-    def __init__(self, config: dict):
-        self.config = config
-
-    def annotate_example(self, api: ModelAPI, data, text):
-        """
-        Annotate the example with the model.
-
-        Args:
-            data: the data from which the text was generated
-            text: the text describing the data
-
-        Returns:
-            A dictionary: {
-                "prompt": the prompt used for the generation,
-                "annotations": the annotations for the text
-            }
-        """
-
-        assert isinstance(text, str) and len(text) > 0, f"Text must be a non-empty string, got {text=}"
-
-        model_service = api._service_prefix() + self.config["model"]
-
-        api.validate_environment(model_service)
-
-        # temporarily disable until this is properly merged: https://github.com/BerriAI/litellm/pull/7832
-
-        # assert litellm.supports_response_schema(
-        #     model_service
-        # ), f"Model {model_service} does not support the JSON response schema."
-
-        try:
-            # This regex:
-            #  - '.' and a negative lookahead
-            #    - Can't be followed by another numer, comma, colon, or spaces* lowercase.
-            #      This is needed for decimals (3.5) and abbreviations (e.g. this).
-            #    - Can be followed by an optional \".
-            #  - '?' or '!' followed by an optional \".
-            #  - Extra chunking shouldn't hurt once I show it preceding context.
-            punc_regex = "\\.(?![0-9]|,|:|\\s*[a-z])\"?|\\?\"?|!\"?"
-            parts = [part for part in re.split(punc_regex, text) if len(part) > 2]
-
-            # This text splitter (https://github.com/mediacloud/sentence-splitter) can properly recognize "e.g." and so on. When a sentence starts with a number, it only works if it's a year number (4 digits). Sentences must begin with capital letters. Unfortunately it doesn't work well with markdown formats, which llm's love to produce.
-            # parts = split_text_into_sentences(text, language='en')
-
-            part_prompts = [self.prompt(data, part) for part in parts]
-            all_annotations = []
-
-            start = time.time()
-            for part, part_prompt in zip(parts, part_prompts):
-                # prompt = self.prompt(data, text)
-
-                logger.debug(f"Prompt: {part_prompt}")
-
-                logger.info("Annotated text:")
-                logger.info(f"\033[34m{part}\033[0m")
-
-                logger.info(f"Waiting for {model_service}.")
-
-                messages = self.construct_message(part_prompt)
-
-                start = time.time()
-                response: str = api.get_model_response_with_retries(messages, model_service)
-
-                # If parse_mode is "raw", extract JSON from the raw output
-                extra_args = self.config.get("extra_args", {})
-                if extra_args.get("parse_mode") == "raw":
-                    response: str = self.extract_json_from_raw(response)
-
-                left = response.find("[")
-                right = response.rfind("]")
-                all_annotations.append(response[left+1:right])
-            elapsed = time.time() - start
-            nresponses = len(parts)
-            logger.info(f"Received {nresponses} responses in {elapsed:.2f} seconds. ({elapsed / nresponses:.2f} seconds per response.)")
-
-            joint_annotations = "{\n\"annotations\": [" + ",\n".join(all_annotations) + "]\n}"
-            # Sometimes the individual json lists end with comma, and then joining them by command causes double commas. This regular expression removes multiples of commas with a single comma. (It replaces single commas with a single comma too, improving formatting.)
-            joint_annotations = re.sub(r"}(?:\s*,)*(?:\s*){", "},\n\t{", joint_annotations)
-            return {
-                "prompt": "; ".join(part_prompts),
-                "annotations": self.parse_annotations(text=text, annotations_json=joint_annotations),
-            }
         except Exception as e:
             traceback.print_exc()
             logger.error(e)

--- a/factgenie/prompting.py
+++ b/factgenie/prompting.py
@@ -22,7 +22,7 @@ class PromptingStrategy(abc.ABC):
 
     def prompt(self, data, to_annotate: str = "{text}"):
         data = self.preprocess_data_for_prompt(data)
-        keyword_dict = { "data": data, "text": to_annotate }
+        keyword_dict = {"data": data, "text": to_annotate}
 
         prompt_template = self.config["prompt_template"]
         prompt_template = template_replace(prompt_template, keyword_dict)

--- a/factgenie/prompting.py
+++ b/factgenie/prompting.py
@@ -20,14 +20,10 @@ class PromptingStrategy(abc.ABC):
         self.extra_args = config.get("extra_args", {})
         self.prompt_strat_kwargs = {}
 
-    def prompt(self, data, to_annotate: str = "{text}", template_override=None):
-        if template_override is not None:
-            prompt_template = template_override
-        else:
-            prompt_template = self.config["prompt_template"]
-
+    def prompt(self, data, to_annotate: str = "{text}"):
         data = self.preprocess_data_for_prompt(data)
 
+        prompt_template = self.config["prompt_template"]
         prompt_template = template_replace(prompt_template, "data", data)
         prompt_template = prompt_template.replace("{text}", to_annotate)
 

--- a/factgenie/text_processing.py
+++ b/factgenie/text_processing.py
@@ -48,9 +48,7 @@ def template_replace(text: str, keyword_dict: dict):
         # Case 1: we have something like {data[key1]}.
         if s.group(2) is not None:
             if type(data) is not dict:
-                raise TypeError(
-                    f"Trying to access dictionary entries in {label_for_data} but it's not a dictionary."
-                )
+                raise TypeError(f"Trying to access dictionary entries in {label_for_data} but it's not a dictionary.")
 
             # The replacement path in the dictionary.
             keys = s.group(2)[1:-1].split("][")
@@ -123,9 +121,7 @@ class TestTemplating(unittest.TestCase):
         self.assertRaises(KeyError, lambda: extract_data(data, ["a", "z"]))
 
     def test_template_wrong_key(self):
-        text = (
-            "Yes in this we have {data[a][z]} and {data[e]} and also {data[a][b][c]}."
-        )
+        text = "Yes in this we have {data[a][z]} and {data[e]} and also {data[a][b][c]}."
         data = {"a": {"b": {"c": "<CC>"}, "d": "<DD>"}, "e": "<EE>"}
         keyword_dict = {"data": data}
         self.assertRaises(KeyError, lambda: template_replace(text, keyword_dict))

--- a/factgenie/text_processing.py
+++ b/factgenie/text_processing.py
@@ -1,0 +1,116 @@
+import re
+import unittest
+
+# Throws `KeyError` when the key is not found.
+def template_replace(text: str, label_for_data: str, data):
+    """
+    Args:
+        text: The template string.
+        label_for_data: How the data is called in the template (e.g. "data" for {data}).
+        data: The data to use for replacing.
+    
+    Replaces in text:
+        - "{data}" with `str(data)`.
+        - "{data[key]}" with `str(data[key])`. Any depth is supported (e.g. "{data[a][b][c]}" will work).
+
+    Exceptions:
+        - TypeError: Raised when using key access (i.e. {data[key]}) on a non-dictionary data.
+        - KeyError: Raised when key doesn't exist in a data.
+
+    The method protects against recursion. I.e. if data = "{data}", it will only replace once.
+    """
+    # Regex matches "{data[...]+}", with at least one [...] key.
+    # Raw would look like: r"{data((?:\[[^\[\]\{\}]*\])+?)}".
+    regex = f"{{{label_for_data}((?:\\[[^\\[\\]\\{{\\}}]*\\])+?)?}}"
+
+    # Once we replace some part of text, we want to have that replaced text inaccessible to future regex searches, as it could potentially cause infinite recursion. Therefore we keep the variable `processed_chars`, which remembers how many chars we have processed so far. After each replace, it will point to the rightmost part of that replce.
+    processed_chars = 0
+
+    while True:
+        # Try to find a match.
+        s = re.search(regex, text[processed_chars:])
+        if s is None:
+            break
+
+        # Find the span to be replaced, taking into account the initial cropping.
+        l, r = s.span()
+        l += processed_chars
+        r += processed_chars
+
+        # Case 1: we have something like {data[key1]}.
+        if s.group(1) is not None:
+            if type(data) is not dict:
+                raise TypeError(f"Trying to access dictionary entries in {label_for_data} but it's not a dictionary.")
+
+            # The replacement path in the dictionary.
+            keys = s.group(1)[1:-1].split("][")
+
+            # Replace.
+            try:
+                replace_with = str(extract_data(data, keys))
+            except KeyError:
+                raise KeyError(f"Could not find path {s.group(0)} in {label_for_data}.")
+
+        # Case 2: we have just {data}.
+        else:
+            replace_with = str(data)
+
+        text = text[:l] + replace_with + text[r:]
+        processed_chars = l + len(replace_with)
+
+    return text
+
+
+def extract_data(data: dict, keys: list[str]):
+    """
+    `extract_data(data, ['a', 'b'])` either returns data['a']['b'] or throws a KeyError when not found.
+    """
+    key = keys[0]
+    tail = keys[1:]
+
+    if key not in data:
+        raise KeyError()
+
+    value = data[key]
+
+    if len(tail) == 0:
+        return value
+    elif type(value) is dict:
+        return extract_data(value, tail)
+    else:
+        raise KeyError()
+
+
+class TestTemplating(unittest.TestCase):
+    def test_template_full(self):
+        text = "Yes in this we have {data[a][d]} and {data[e]} and also {data[a][b][c]} and {data[num]}."
+        data = {'a': {'b': {'c': '<CC>'}, 'd': '<DD>'}, 'e': '<EE>', 'num': 33}
+        self.assertEqual(template_replace(text, "data", data), "Yes in this we have <DD> and <EE> and also <CC> and 33.")
+
+    def test_template_non_dict(self):
+        text = "Cats and {data}."
+        data = "dogs"
+        self.assertEqual(template_replace(text, "data", data), "Cats and dogs.")
+
+    def test_extract(self):
+        data = {'a': {'b': {'c': '<CC>'}, 'd': '<DD>'}, 'e': '<EE>'}
+        path = ['a', 'b', 'c']
+        self.assertEqual(extract_data(data, path), '<CC>')
+    
+    def test_template_no_recursion(self):
+        text = "data[a] is '{data[a]}'"
+        data = {'a': '{data[a]}'}
+        self.assertEqual(template_replace(text, "data", data), "data[a] is '{data[a]}'")
+
+    def test_extract_wrong_key(self):
+        data = {'a': {'b': {'c': '<CC>'}, 'd': '<DD>'}, 'e': '<EE>'}
+        self.assertRaises(KeyError, lambda: extract_data(data, ['a', 'z']))
+
+    def test_template_wrong_key(self):
+        text = "Yes in this we have {data[a][z]} and {data[e]} and also {data[a][b][c]}."
+        data = {'a': {'b': {'c': '<CC>'}, 'd': '<DD>'}, 'e': '<EE>'}
+        self.assertRaises(KeyError, lambda: template_replace(text, "data", data))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/factgenie/text_processing.py
+++ b/factgenie/text_processing.py
@@ -1,27 +1,32 @@
+#!/usr/bin/env python3
+
 import re
 import unittest
 
+
 # Throws `KeyError` when the key is not found.
-def template_replace(text: str, label_for_data: str, data):
+def template_replace(text: str, keyword_dict: dict):
     """
     Args:
         text: The template string.
-        label_for_data: How the data is called in the template (e.g. "data" for {data}).
-        data: The data to use for replacing.
-    
-    Replaces in text:
+        keyword_dict: A dictionary defining template keys and corresponding values. See the example below.
+
+    Example: `keyword_dict = { "data": data }` will replace:
         - "{data}" with `str(data)`.
         - "{data[key]}" with `str(data[key])`. Any depth is supported (e.g. "{data[a][b][c]}" will work).
 
     Exceptions:
         - TypeError: Raised when using key access (i.e. {data[key]}) on a non-dictionary data.
-        - KeyError: Raised when key doesn't exist in a data.
+        - KeyError: Raised when key doesn't exist in the data.
 
     The method protects against recursion. I.e. if data = "{data}", it will only replace once.
+
+    "{unknown_keywords}" in text will not be detected.
     """
     # Regex matches "{data[...]+}", with at least one [...] key.
+    # Where 'data' is one of the keyword_dict keys.
     # Raw would look like: r"{data((?:\[[^\[\]\{\}]*\])+?)}".
-    regex = f"{{{label_for_data}((?:\\[[^\\[\\]\\{{\\}}]*\\])+?)?}}"
+    regex = f"{{({'|'.join(keyword_dict.keys())})((?:\\[[^\\[\\]\\{{\\}}]*\\])+?)?}}"
 
     # Once we replace some part of text, we want to have that replaced text inaccessible to future regex searches, as it could potentially cause infinite recursion. Therefore we keep the variable `processed_chars`, which remembers how many chars we have processed so far. After each replace, it will point to the rightmost part of that replce.
     processed_chars = 0
@@ -32,18 +37,23 @@ def template_replace(text: str, label_for_data: str, data):
         if s is None:
             break
 
+        label_for_data = s.group(1)
+        data = keyword_dict[label_for_data]
+
         # Find the span to be replaced, taking into account the initial cropping.
         l, r = s.span()
         l += processed_chars
         r += processed_chars
 
         # Case 1: we have something like {data[key1]}.
-        if s.group(1) is not None:
+        if s.group(2) is not None:
             if type(data) is not dict:
-                raise TypeError(f"Trying to access dictionary entries in {label_for_data} but it's not a dictionary.")
+                raise TypeError(
+                    f"Trying to access dictionary entries in {label_for_data} but it's not a dictionary."
+                )
 
             # The replacement path in the dictionary.
-            keys = s.group(1)[1:-1].split("][")
+            keys = s.group(2)[1:-1].split("][")
 
             # Replace.
             try:
@@ -84,33 +94,42 @@ def extract_data(data: dict, keys: list[str]):
 class TestTemplating(unittest.TestCase):
     def test_template_full(self):
         text = "Yes in this we have {data[a][d]} and {data[e]} and also {data[a][b][c]} and {data[num]}."
-        data = {'a': {'b': {'c': '<CC>'}, 'd': '<DD>'}, 'e': '<EE>', 'num': 33}
-        self.assertEqual(template_replace(text, "data", data), "Yes in this we have <DD> and <EE> and also <CC> and 33.")
+        data = {"a": {"b": {"c": "<CC>"}, "d": "<DD>"}, "e": "<EE>", "num": 33}
+        keyword_dict = {"data": data}
+        self.assertEqual(
+            template_replace(text, keyword_dict),
+            "Yes in this we have <DD> and <EE> and also <CC> and 33.",
+        )
 
     def test_template_non_dict(self):
         text = "Cats and {data}."
         data = "dogs"
-        self.assertEqual(template_replace(text, "data", data), "Cats and dogs.")
+        keyword_dict = {"data": data}
+        self.assertEqual(template_replace(text, keyword_dict), "Cats and dogs.")
 
     def test_extract(self):
-        data = {'a': {'b': {'c': '<CC>'}, 'd': '<DD>'}, 'e': '<EE>'}
-        path = ['a', 'b', 'c']
-        self.assertEqual(extract_data(data, path), '<CC>')
-    
+        data = {"a": {"b": {"c": "<CC>"}, "d": "<DD>"}, "e": "<EE>"}
+        path = ["a", "b", "c"]
+        self.assertEqual(extract_data(data, path), "<CC>")
+
     def test_template_no_recursion(self):
         text = "data[a] is '{data[a]}'"
-        data = {'a': '{data[a]}'}
-        self.assertEqual(template_replace(text, "data", data), "data[a] is '{data[a]}'")
+        data = {"a": "{data[a]}"}
+        keyword_dict = {"data": data}
+        self.assertEqual(template_replace(text, keyword_dict), "data[a] is '{data[a]}'")
 
     def test_extract_wrong_key(self):
-        data = {'a': {'b': {'c': '<CC>'}, 'd': '<DD>'}, 'e': '<EE>'}
-        self.assertRaises(KeyError, lambda: extract_data(data, ['a', 'z']))
+        data = {"a": {"b": {"c": "<CC>"}, "d": "<DD>"}, "e": "<EE>"}
+        self.assertRaises(KeyError, lambda: extract_data(data, ["a", "z"]))
 
     def test_template_wrong_key(self):
-        text = "Yes in this we have {data[a][z]} and {data[e]} and also {data[a][b][c]}."
-        data = {'a': {'b': {'c': '<CC>'}, 'd': '<DD>'}, 'e': '<EE>'}
-        self.assertRaises(KeyError, lambda: template_replace(text, "data", data))
+        text = (
+            "Yes in this we have {data[a][z]} and {data[e]} and also {data[a][b][c]}."
+        )
+        data = {"a": {"b": {"c": "<CC>"}, "d": "<DD>"}, "e": "<EE>"}
+        keyword_dict = {"data": data}
+        self.assertRaises(KeyError, lambda: template_replace(text, keyword_dict))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR adds a new file `text_processing.py`, which handles template replacing better than before (especially for dictionaries).

There is a function `template_replace(...)` , which replaces "dictionary entries" of any depth in the template. This means things like "{data[a][b][c][d]}". It also replaces bare "{data}", if present.

Advantages of this compared to what was there before:
- Any depth of replacing. (Before I could do `{data[a]}` but not `{data[a][b]}`.)
- Reusable, as it contains a parameter for what label should be (e.g. "data" for "{data[a]}" or "code_result" for "{code_result[a]").
- Makes the `prompt` method really nice and clean.
- Raises appropriate exceptions (missing key, or using "{data[a]}" when `data` is not a dictionary). This pops up right in the browser, which I think is appropriate. It's makes the workflow like: *runs data generation, error pops up about incorrect key, clicks show configuration and edits the prompt typo, runs again*.
- Includes a protection against infinite recursion (e.g. if `data[key]` contains "{data[key]}" again, it won't lead to another replacement). (This would've only been a problem because of having to use `re.search` in a loop.)
- Includes unit tests to check that everything works as it should.
- Automatically converts both `data` and `data[a][b]...` to strings through `str(...)`. (No rounding or any custom formatting, as this is more of a convenience and should preferably done before on `data` itself.)