### PR TITLE
Extract reasoning trace from the `reasoning_content` field

### DIFF
--- a/factgenie/prompting/strategies/base.py
+++ b/factgenie/prompting/strategies/base.py
@@ -8,7 +8,12 @@ import unittest
 from factgenie.campaign import CampaignMode
 from factgenie.prompting import transforms as t
 from factgenie.prompting.model_apis import MockingAPI, ModelAPI
-from factgenie.prompting.registry import track_subclasses, untracked, Registry, UnregisteredTracker
+from factgenie.prompting.registry import (
+    Registry,
+    UnregisteredTracker,
+    track_subclasses,
+    untracked,
+)
 
 logger = logging.getLogger("factgenie")
 
@@ -36,8 +41,9 @@ class PromptingStrategy(abc.ABC):
                 - 'output': (for LLM_GEN) a string containing the output text.
                 - 'annotations': (for LLM_EVAL) a list of annotations.
                 - 'metadata': A dictionary containing any information from the prompting you wish to have saved in the campaign output. Typically containing a single key 'prompt'.
-                - ...all other keys generated in the PromptingStrategy will be ignored.
-            A dictionary with the prompt and either 'output' or 'annotations'
+                - 'thinking_trace': (optional) The reasoning trace from the LLM if available.
+                - Other keys may be preserved depending on the strategy implementation.
+            A dictionary with the expected output fields and any additional preserved fields
         """
         # TODO: Add the description for what the list of annotations looks like (inside """... Returns: ...""").
         pass

--- a/factgenie/prompting/strategies/base.py
+++ b/factgenie/prompting/strategies/base.py
@@ -70,6 +70,7 @@ class SequentialStrategy(PromptingStrategy):
     TEXT = "text"
     OUTPUT = "output"
     ANNOTATIONS = "annotations"
+    THINKING_TRACE = "thinking_trace"
 
     def __init__(self, config, mode: str):
         super().__init__(config, mode)
@@ -86,7 +87,7 @@ class SequentialStrategy(PromptingStrategy):
             expected_outputs = {self.OUTPUT}
         elif self.mode == CampaignMode.LLM_EVAL:
             current_keys = {self.DATA, self.TEXT}
-            expected_outputs = {self.ANNOTATIONS}
+            expected_outputs = {self.ANNOTATIONS, self.THINKING_TRACE}
         else:
             raise NotImplementedError(f"{self.mode} is not implemented")
 

--- a/factgenie/prompting/strategies/eval_raw_output.py
+++ b/factgenie/prompting/strategies/eval_raw_output.py
@@ -1,5 +1,6 @@
 import logging
 
+from factgenie.colors import Ansi
 from factgenie.annotations import AnnotationModelFactory
 from factgenie.prompting import transforms as t
 from factgenie.prompting.strategies import SequentialStrategy, register_llm_eval
@@ -41,6 +42,7 @@ class RawOutputAnnotationStrategy(SequentialStrategy):
                 remove_from_input=True,
                 log_as="THINKING",
             ),
+            t.Log(text="Thinking trace: ", field=THINKING_TRACE, color=Ansi.DARK_GRAY, log_level="debug"),
             t.ExtractJson(ANNOTATIONS_RAW, EXTRACTED),
             t.ParseAnnotations(
                 EXTRACTED,


### PR DESCRIPTION
LiteLLM now [officially saves](https://docs.litellm.ai/docs/reasoning_content) the reasoning trace from the model into the `reasoning_content` field in the response.

With this PR, factgenie parses this field and saves it into `thinking_trace` in the annotation file (same as we've done before with the content between the `<think>...</think>` tags).