### PR TITLE
Show unicode characters in JSON files

### DIFF
--- a/factgenie/app.py
+++ b/factgenie/app.py
@@ -86,7 +86,7 @@ def annotate_url(current_url):
 
 @app.template_filter("prettify_json")
 def prettify_json(value):
-    return json.dumps(value, sort_keys=True, indent=4, separators=(",", ": "))
+    return json.dumps(value, sort_keys=True, indent=4, separators=(",", ": "), ensure_ascii=False)
 
 
 # -----------------

--- a/factgenie/campaign.py
+++ b/factgenie/campaign.py
@@ -92,7 +92,7 @@ class Campaign:
 
     def update_metadata(self):
         with open(self.metadata_path, "w") as f:
-            json.dump(self.metadata, f, indent=4)
+            json.dump(self.metadata, f, indent=4, ensure_ascii=False)
 
     def load_metadata(self):
         with open(self.metadata_path) as f:

--- a/factgenie/crowdsourcing.py
+++ b/factgenie/crowdsourcing.py
@@ -44,6 +44,7 @@ def create_crowdsourcing_campaign(app, campaign_id, config, campaign_data):
                 },
                 f,
                 indent=4,
+                ensure_ascii=False,
             )
 
         # prepare the crowdsourcing HTML page

--- a/factgenie/iaa/cli.py
+++ b/factgenie/iaa/cli.py
@@ -137,7 +137,7 @@ def gamma_command(
     # Save to JSON if output file specified
     if output:
         with open(output, "w") as f:
-            json.dump(gamma_results, f, indent=2)
+            json.dump(gamma_results, f, indent=2, ensure_ascii=False)
         logger.info(f"Gamma results saved to {output}")
 
 
@@ -263,7 +263,7 @@ def f1_command(
     # Save to JSON if output file specified
     if output:
         with open(output, "w") as f:
-            json.dump(f1_results, f, indent=2)
+            json.dump(f1_results, f, indent=2, ensure_ascii=False)
         logger.info(f"F1 results saved to {output}")
 
 
@@ -375,5 +375,5 @@ def pearson_command(
     # Save to JSON if output file specified
     if output:
         with open(output, "w") as f:
-            json.dump(pearson_results, f, indent=2)
+            json.dump(pearson_results, f, indent=2, ensure_ascii=False)
         logger.info(f"Pearson correlation results saved to {output}")

--- a/factgenie/llm_campaign.py
+++ b/factgenie/llm_campaign.py
@@ -56,6 +56,7 @@ def create_llm_campaign(app, mode, campaign_id, config, campaign_data, datasets,
                 },
                 f,
                 indent=4,
+                ensure_ascii=False,
             )
     except Exception as e:
         # cleanup
@@ -97,7 +98,7 @@ def duplicate_llm_campaign(app, mode, campaign_id, new_campaign_id):
     metadata["status"] = CampaignStatus.IDLE
 
     with open(metadata_path, "w") as f:
-        json.dump(metadata, f, indent=4)
+        json.dump(metadata, f, indent=4, ensure_ascii=False)
 
     return utils.success()
 
@@ -325,6 +326,6 @@ def save_generation_outputs(app, campaign_id, setup_id):
 
     with open(path / f"{campaign_id}.jsonl", "w") as f:
         for example in outputs:
-            f.write(json.dumps(example) + "\n")
+            f.write(json.dumps(example, ensure_ascii=False) + "\n")
 
     return utils.success()

--- a/factgenie/stats/cli.py
+++ b/factgenie/stats/cli.py
@@ -94,7 +94,7 @@ def counts_command(
     if output:
         try:
             with open(output, "w") as f:
-                json.dump(stats, f, indent=2)
+                json.dump(stats, f, indent=2, ensure_ascii=False)
             logger.info(f"Statistics saved to {output}")
             print(f"\nStatistics saved to {output}")
         except Exception as e:

--- a/factgenie/utils.py
+++ b/factgenie/utils.py
@@ -221,7 +221,7 @@ def resumable_download(
 
 
 def announce(announcer, payload):
-    msg = format_sse(data=json.dumps(payload))
+    msg = format_sse(data=json.dumps(payload, ensure_ascii=False))
     if announcer is not None:
         announcer.announce(msg=msg)
 

--- a/factgenie/workflows.py
+++ b/factgenie/workflows.py
@@ -729,7 +729,7 @@ def export_outputs(app, dataset_id, split, setup_id):
     with open(tmp_file_path, "w") as f:
         for _, row in outputs.iterrows():
             j = row.to_dict()
-            f.write(json.dumps(j) + "\n")
+            f.write(json.dumps(j, ensure_ascii=False) + "\n")
 
     with zipfile.ZipFile(zip_buffer, "w") as zip_file:
         zip_file.write(
@@ -856,7 +856,7 @@ def upload_model_outputs(dataset, split, setup_id, model_outputs):
                 "example_idx": i,
                 "output": out,
             }
-            f.write(json.dumps(j) + "\n")
+            f.write(json.dumps(j, ensure_ascii=False) + "\n")
 
     with open(f"{path.parent}/metadata.json", "w") as f:
         json.dump(
@@ -866,6 +866,7 @@ def upload_model_outputs(dataset, split, setup_id, model_outputs):
             },
             f,
             indent=4,
+            ensure_ascii=False,
         )
 
 
@@ -990,6 +991,6 @@ def save_record(mode, campaign, row, result):
 
     # append the record to the file from the current run
     with open(os.path.join(save_dir, filename), "a") as f:
-        f.write(json.dumps(record, allow_nan=True) + "\n")
+        f.write(json.dumps(record, allow_nan=True, ensure_ascii=False) + "\n")
 
     return record


### PR DESCRIPTION
This PR makes the raw output JSON files more readable by using the flag `ensure_ascii=False`. 

The flag prevents converting Unicode characters to their codes (which previously made the annotations in some languages unreadable with the naked eye).